### PR TITLE
Moving from .co to .io [ do not merge yet ]

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ yarn build # to build index to ./public
 To present merge your changes to `staging` branch. CI will build and then deploy it to GitHub pages (check web-static-[staging,production] repos):
 
 Currently, there is only one release candidate branch `staging` accessible on:
-- [staging.codeyourfuture.co](http://staging.codeyourfuture.co)
+- [staging.codeyourfuture.io](http://staging.codeyourfuture.io)
 
 ## Contribute
 
@@ -30,7 +30,7 @@ Development workflow is tracked on [CYF Web](https://trello.com/b/wLDcxrly/cyf-w
 
 If you found an error, got idea for improvement, or new feature you can submit a new ticket to `Ideas`.
 
-To get access to Trello `admin[at]codeyourfuture.co`, or let us know on Slack and we will add you to the project.
+To get access to Trello `admin[at]codeyourfuture.io`, or let us know on Slack and we will add you to the project.
 
 To contribute please follow instructions:
 
@@ -40,10 +40,10 @@ To contribute please follow instructions:
 - when you're finished, submit a PR to the `staging` branch for review and move the task to `In Review` list (currently, we have only one review environment, so if you see another PR make sure its safe to merge to `staging`)
 - the code is approved by adding _LGTM_ to comment
 - after the PR is approved the reviewer, or contributor merges PR
-- after merging and a successful deploy, get someone to review the page in the (staging environment)[staging.codeyourfuture.co], to make sure that everything works
+- after merging and a successful deploy, get someone to review the page in the (staging environment)[staging.codeyourfuture.io], to make sure that everything works
 - Then, submit a PR from `staging` to `master`
 - when the PR is merged to master, automatic build on CircleCI deploys the website
-- briefly look on the web to see your changes are fine; [http://codeyourfuture.co/](http://codeyourfuture.co/)
+- briefly look on the web to see your changes are fine; [http://codeyourfuture.io/](http://codeyourfuture.io/)
 - move task fro in `Review` to `Done`
 
 Thank you.

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -19,16 +19,16 @@ fi
 
 ## Some weird github pages requirement
 if [ $BRANCH == "production" ]; then
-	echo "codeyourfuture.co" > ./build/CNAME
+	echo "codeyourfuture.io" > ./build/CNAME
 else
-  echo "$BRANCH.codeyourfuture.co" > ./build/CNAME
+  echo "$BRANCH.codeyourfuture.io" > ./build/CNAME
 fi
 ##
 git clone git@github.com:Code-Your-Future/$REPO_NAME.git
 cd $REPO_NAME
 git rm -r ./*
 cp -a ../build/* .
-git config --global user.email "admin@codeyourfuture.co"
+git config --global user.email "admin@codeyourfuture.io"
 git config --global user.name "Automated bot"
 git add .
 git commit -m "Rebuilt on $DATE"

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -34,7 +34,7 @@ const handleLink = (linkName) => {
       URL="https://www.linkedin.com/company/codeyourfuture"
       break;
     case "email":
-      URL="mailto:contact@codeyourfuture.co"
+      URL="mailto:contact@codeyourfuture.io"
       break;
     case "blog":
       URL="https://medium.com/@CodeYourFuture"

--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -11,7 +11,7 @@ const AboutText = (
     <p>Last year we launched the first cohort of our  6-month web development programme, coached by a group of professional developers. Today we are running new classes in London and Glasgow. This is <strong>just the beginning</strong>. With your help we will be expanding to other regions and cities.</p>
     <p>If you are interested in participating as a <Link to="students">student</Link>, <Link to="volunteers">coach or volunteer</Link>, sign up!</p>
     <p>
-    For all other inquiries please contact us at <Link to="mailto:contact@codeyourfuture.co" title="Contact us">contact@codeyourfuture.co</Link>
+    For all other inquiries please contact us at <Link to="mailto:contact@codeyourfuture.io" title="Contact us">contact@codeyourfuture.io</Link>
     <br /><br />
     </p>
   </div>

--- a/src/pages/Partners.js
+++ b/src/pages/Partners.js
@@ -11,7 +11,7 @@ const PartnersText = (
     <p>Together we’ll help to solve both of these issues.</p>
 
     <div className="section-bottom-link">
-      <Link className="big-link-3 btn" to="mailto:contact@codeyourfuture.co?subject=Interested in partnership">Get in Touch</Link>
+      <Link className="big-link-3 btn" to="mailto:contact@codeyourfuture.io?subject=Interested in partnership">Get in Touch</Link>
     </div>
   </div>
 );


### PR DESCRIPTION
This is to update all the references from the domain .co to .io.

After merging, we need to change the rules on both accounts of cloudflare (for .io and for .co) so they match what we are looking for: redirect .co to .io

We'll also need to change the github pages settings to codeyourfuture.io

**[ DONE ]** Emails admin and contact are being configured (subject to the normal pains of google groups)