### PR TITLE
Change icon definition for iOS devices

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,8 @@
     -->
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
   <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.png">
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/icon-192.png">
+  <link rel="apple-touch-icon" sizes="152x152" href="%PUBLIC_URL%/icon-512.png">
   <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
     crossorigin="anonymous">
   <link rel="stylesheet" href="%PUBLIC_URL%/legacy.css">


### PR DESCRIPTION
Add a link meta tag for iOS which doesn't take the manifest file into account when defining icon to display on homepage