### PR TITLE
Redirects to new apply form

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -4,7 +4,6 @@ import history from './lib/history';
 
 import {
   About,
-  Apply,
   ApplySuccess,
   Donate,
   Event,
@@ -55,7 +54,14 @@ const Routes = () => (
       <Route exact path="/students.html" component={Students} />
       <Route exact path="/volunteers" component={Volunteers} />
       <Route exact path="/volunteers.html" component={Volunteers} />
-      <Route exact path="/apply/:formType" component={Apply} />
+      <Route
+        exact
+        path="/apply/:formType"
+        component={() => {
+          window.location = 'https://application-process.codeyourfuture.io/';
+          return null;
+        }}
+      />
       <Route exact path="/apply/success/:formType" component={ApplySuccess} />
       <Route exact path="/partners" component={Partners} />
       <Route exact path="/partners.html" component={Partners} />


### PR DESCRIPTION
### Motivation
https://codeyourfuture.slack.com/archives/C3Y6RFWBD/p1548363286099900?thread_ts=1548354772.095300&cid=C3Y6RFWBD
> If I type codeyourfuture.io/apply/student, the old application page comes up, unfortunately in the past we have given away this link on some ads, and I was wondering if this link could be linked to https://application-process.codeyourfuture.io/?

Ngrok for fast testing: http://467c126f.ngrok.io/

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
