### PR TITLE
removes redirect from other forms

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -4,6 +4,7 @@ import history from './lib/history';
 
 import {
   About,
+  Apply,
   ApplySuccess,
   Donate,
   Event,
@@ -56,12 +57,13 @@ const Routes = () => (
       <Route exact path="/volunteers.html" component={Volunteers} />
       <Route
         exact
-        path="/apply/:formType"
+        path="/apply/student"
         component={() => {
           window.location = 'https://application-process.codeyourfuture.io/';
           return null;
         }}
       />
+      <Route exact path="/apply/:formType" component={Apply} />
       <Route exact path="/apply/success/:formType" component={ApplySuccess} />
       <Route exact path="/partners" component={Partners} />
       <Route exact path="/partners.html" component={Partners} />


### PR DESCRIPTION
### Motivation
@here It looks like something is off with the links on our Mentor/Volunteer page here: https://codeyourfuture.io/volunteers

Clicking on either button for Mentors or Volunteers is supposed to direct to a typeform but now redirects to https://application-process.codeyourfuture.io/ (edited)

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
