### PR TITLE
Remove misleading text that would deter asylum seekers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -38,7 +38,7 @@
   </script>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="We are a non-profit organisation supporting refugees with the dream of becoming developers.">
+  <meta name="description" content="We are a non-profit organisation supporting refugees, asylum seekers and underprivileged individuals with the dream of becoming software developers.">
   <script src='https://www.google.com/recaptcha/api.js' async defer></script>
   <title>Code Your Future</title>
 

--- a/src/components/banner/__snapshots__/index.test.js.snap
+++ b/src/components/banner/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`Banner Component renders 1`] = `
   />
   <Styled(div)>
     <h1>
-      Coding School for Refugees, Disadvantaged and Underprivileged People
+      Coding School for Refugees, Asylum Seekers and Underprivileged People
     </h1>
     <p>
       Learn to code and find a job

--- a/src/components/banner/index.js
+++ b/src/components/banner/index.js
@@ -33,7 +33,7 @@ const Banner = () => (
     <BannerImage src={homepagebanner} alt="teaching=refugees-to-code" />
     <BannerText>
       <h1>
-        Coding School for Refugees, Disadvantaged and Underprivileged People
+        Coding School for Refugees, Asylum Seekers and Underprivileged People
       </h1>
       <p>Learn to code and find a job</p>
       <div className="page-title-bottom-link">

--- a/src/pages/about-us/index.js
+++ b/src/pages/about-us/index.js
@@ -8,7 +8,7 @@ const AboutText = (
   <div>
     <p>
       We are a non-profit organisation supporting refugees and underprivileged
-      individuals with the dream of becoming developers.
+      individuals with the dream of becoming software developers.
     </p>
     <p>
       In their journey of interrupted lives, unfinished studies and integration

--- a/src/pages/south-africa/index.js
+++ b/src/pages/south-africa/index.js
@@ -9,9 +9,9 @@ const SouthAfricaText = (
   <div>
     <p>
       Code Your Future is a non-profit organisation supporting refugees with the
-      dream of becoming developers. In their journey of interrupted lives,
-      unfinished studies and integration challenges, many asylum seekers and
-      refugees yearn to update their tech skills, but lack learning
+      dream of becoming software developers. In their journey of interrupted
+      lives, unfinished studies and integration challenges, many asylum seekers
+      and refugees yearn to update their tech skills, but lack learning
       opportunities. We want to change this by offering a program in which they
       are mentored by professional developers in order to prepare them to be
       able to work as software developers.

--- a/src/pages/students/index.js
+++ b/src/pages/students/index.js
@@ -48,10 +48,6 @@ const Students = () => {
             <div id="requirements" className="col-sm-6 col-md-6 block-2-box">
               <h3>Requirements</h3>
               <ul className="text-left">
-                <li>
-                  Have the relevant documents to work in the country of
-                  residence.
-                </li>
                 <li>No previous coding experience is required!</li>
                 <li>Speak good English</li>
                 <li>Ready to commit to over 30 hours of learning per week</li>

--- a/src/pages/volunteers/__snapshots__/index.test.js.snap
+++ b/src/pages/volunteers/__snapshots__/index.test.js.snap
@@ -21,8 +21,7 @@ exports[`Volunteers Page renders correctly 1`] = `
           <strong>
             Volunteers from virtually any background
           </strong>
-           
-          to help us run and grow our organisation.
+           to help us run and grow our organisation.
         </li>
         <li>
           Professionals from the tech industry to join our

--- a/src/pages/volunteers/__snapshots__/index.test.js.snap
+++ b/src/pages/volunteers/__snapshots__/index.test.js.snap
@@ -21,6 +21,7 @@ exports[`Volunteers Page renders correctly 1`] = `
           <strong>
             Volunteers from virtually any background
           </strong>
+           
           to help us run and grow our organisation.
         </li>
         <li>

--- a/src/pages/volunteers/index.js
+++ b/src/pages/volunteers/index.js
@@ -20,8 +20,8 @@ const Volunteers = () => (
         <p>{Content.Volunteers.Body.Two}</p>
         <ul>
           <li>
-            <strong>Volunteers from virtually any background</strong>
-            to help us run and grow our organisation.
+            <strong>Volunteers from virtually any background</strong> to help us
+            run and grow our organisation.
           </li>
           <li>
             Professionals from the tech industry to join our{' '}


### PR DESCRIPTION
### Motivation

- The wording was mistakenly updated in #161 to exclude asylum seekers.
- Disadvantaged and underprivileged [are synonyms](https://wikidiff.com/underprivileged/disadvantaged) so don't need to both be prominently placed in every sentence.